### PR TITLE
Improve onboarding experience and add cosmetic progression

### DIFF
--- a/lib/ad_provider.dart
+++ b/lib/ad_provider.dart
@@ -7,7 +7,9 @@ class AdProvider with ChangeNotifier {
   RewardedAd? _rewardedAd;
   InterstitialAd? _interstitialAd;
   bool _isRewardedAdReady = false;
-  int _gamesUntilAd = 3;
+  int _runsCompleted = 0;
+  Duration _timeSinceLastInterstitial = Duration.zero;
+  DateTime? _lastInterstitialShownAt;
 
   // Ad Unit IDs
   final String _rewardAdUnitId = Platform.isAndroid
@@ -80,25 +82,49 @@ class AdProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  void showInterstitialAdIfNeeded() {
-    _gamesUntilAd--;
-    if (_gamesUntilAd <= 0) {
-      if (_interstitialAd != null) {
-        _interstitialAd!.fullScreenContentCallback = FullScreenContentCallback(
-          onAdDismissedFullScreenContent: (ad) {
-            ad.dispose();
-            loadInterstitialAd(); // Pre-load the next one
-          },
-          onAdFailedToShowFullScreenContent: (ad, error) {
-            ad.dispose();
-            loadInterstitialAd();
-          },
-        );
-        _interstitialAd!.show();
-        _gamesUntilAd = 3; // Reset counter
-      } else {
-        loadInterstitialAd(); // If it wasn't ready, try loading again
+  void registerRunEnd(Duration runDuration) {
+    if (runDuration <= Duration.zero) {
+      return;
+    }
+    _runsCompleted++;
+    _timeSinceLastInterstitial += runDuration;
+  }
+
+  void maybeShowInterstitial({
+    required Duration lastRunDuration,
+    required VoidCallback onClosed,
+  }) {
+    final bool skipForFirstRuns = _runsCompleted <= 2;
+    final bool wasShortRun = lastRunDuration.inSeconds < 20;
+    final DateTime now = DateTime.now();
+    final bool elapsedSinceLastInterstitial = _lastInterstitialShownAt == null ||
+        now.difference(_lastInterstitialShownAt!) >= const Duration(seconds: 60);
+    final bool accumulatedTimeReached =
+        _timeSinceLastInterstitial >= const Duration(seconds: 60);
+
+    if (!skipForFirstRuns && !wasShortRun &&
+        elapsedSinceLastInterstitial && accumulatedTimeReached &&
+        _interstitialAd != null) {
+      _interstitialAd!.fullScreenContentCallback = FullScreenContentCallback(
+        onAdDismissedFullScreenContent: (ad) {
+          ad.dispose();
+          _lastInterstitialShownAt = DateTime.now();
+          _timeSinceLastInterstitial = Duration.zero;
+          loadInterstitialAd();
+          onClosed();
+        },
+        onAdFailedToShowFullScreenContent: (ad, error) {
+          ad.dispose();
+          loadInterstitialAd();
+          onClosed();
+        },
+      );
+      _interstitialAd!.show();
+    } else {
+      if (_interstitialAd == null) {
+        loadInterstitialAd();
       }
+      onClosed();
     }
   }
 

--- a/lib/drawing_painter.dart
+++ b/lib/drawing_painter.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'coin_provider.dart';
 import 'line_provider.dart';
 import 'obstacle_provider.dart';
+import 'player_skin.dart';
 
 /// Renders the complete game world, including background elements,
 /// the player avatar, obstacles, coins and drawn platforms.
@@ -14,12 +15,14 @@ class DrawingPainter extends CustomPainter {
     required this.lines,
     required this.obstacles,
     required this.coins,
+    required this.skin,
   });
 
   final Offset playerPosition;
   final List<DrawnLine> lines;
   final List<Obstacle> obstacles;
   final List<Coin> coins;
+  final PlayerSkin skin;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -78,15 +81,15 @@ class DrawingPainter extends CustomPainter {
     const double radius = 20;
     final playerRect = Rect.fromCircle(center: playerPosition, radius: radius);
     final playerPaint = Paint()
-      ..shader = const RadialGradient(
-        colors: [Color(0xFF38BDF8), Color(0xFF1D4ED8)],
+      ..shader = RadialGradient(
+        colors: [skin.primaryColor, skin.secondaryColor],
         center: Alignment.topLeft,
         radius: 1.2,
       ).createShader(playerRect);
     canvas.drawCircle(playerPosition, radius, playerPaint);
 
     final auraPaint = Paint()
-      ..color = const Color(0xFF38BDF8).withOpacity(0.35)
+      ..color = skin.auraColor.withOpacity(0.35)
       ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 12);
     canvas.drawCircle(playerPosition, radius + 12, auraPaint);
   }
@@ -157,7 +160,7 @@ class DrawingPainter extends CustomPainter {
       final t = (1 - age.inMilliseconds / LineProvider.lineLifetime.inMilliseconds)
           .clamp(0.0, 1.0);
       final paint = Paint()
-        ..color = const Color(0xFFA855F7).withOpacity(t)
+        ..color = skin.trailColor.withOpacity(t)
         ..strokeCap = StrokeCap.round
         ..strokeJoin = StrokeJoin.round
         ..strokeWidth = 8

--- a/lib/game_screen.dart
+++ b/lib/game_screen.dart
@@ -8,6 +8,8 @@ import 'drawing_painter.dart';
 import 'line_provider.dart';
 import 'coin_provider.dart';
 import 'obstacle_provider.dart';
+import 'meta_provider.dart';
+import 'player_skin.dart';
 
 class GameScreen extends StatefulWidget {
   const GameScreen({super.key});
@@ -24,7 +26,7 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     _gameProvider = Provider.of<GameProvider>(context, listen: false);
-    
+
     // Use a post-frame callback to ensure the layout is complete
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -34,12 +36,76 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
     });
   }
 
+  Future<void> _showSkinShop(BuildContext context) async {
+    final rootContext = context;
+    await showModalBottomSheet(
+      context: context,
+      barrierColor: Colors.black.withOpacity(0.7),
+      backgroundColor: const Color(0xFF020617),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      builder: (sheetContext) {
+        return SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+            child: Consumer<MetaProvider>(
+              builder: (context, meta, _) {
+                if (!meta.isReady) {
+                  return const Center(
+                    child: CircularProgressIndicator(),
+                  );
+                }
+                final textTheme = Theme.of(context).textTheme;
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: Text(
+                        'Unlock Skins',
+                        style: textTheme.titleLarge?.copyWith(
+                          color: Colors.white,
+                          fontSize: 24,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Center(child: _buildWalletBanner(context, meta)),
+                    const SizedBox(height: 20),
+                    SizedBox(
+                      height: 320,
+                      child: ListView.separated(
+                        itemCount: meta.skins.length,
+                        shrinkWrap: true,
+                        itemBuilder: (itemContext, index) {
+                          final skin = meta.skins[index];
+                          return _buildSkinTile(
+                            rootContext: rootContext,
+                            meta: meta,
+                            skin: skin,
+                          );
+                        },
+                        separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
-        child: Consumer4<GameProvider, LineProvider, ObstacleProvider, CoinProvider>(
-          builder: (context, game, lineProvider, obstacleProvider, coinProvider, child) {
+        child: Consumer5<GameProvider, LineProvider, ObstacleProvider, CoinProvider, MetaProvider>(
+          builder: (context, game, lineProvider, obstacleProvider, coinProvider, metaProvider, child) {
             return LayoutBuilder(
               builder: (context, constraints) {
                 final size = Size(constraints.maxWidth, constraints.maxHeight);
@@ -71,6 +137,7 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
                     final started = lineProvider.startNewLine(details.localPosition);
                     _isDrawingGestureActive = started;
                     if (started) {
+                      game.markLineUsed();
                       HapticFeedback.lightImpact();
                     }
                   },
@@ -105,10 +172,12 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
                             lines: lineProvider.lines,
                             obstacles: obstacleProvider.obstacles,
                             coins: coinProvider.coins,
+                            skin: metaProvider.selectedSkin,
                           ),
                         ),
                       ),
-                      _buildGameUI(context, game, lineProvider),
+                      _buildTutorialOverlay(context, game),
+                      _buildGameUI(context, game, lineProvider, metaProvider),
                     ],
                   ),
                 );
@@ -124,20 +193,21 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
     BuildContext context,
     GameProvider game,
     LineProvider lineProvider,
+    MetaProvider meta,
   ) {
     switch (game.gameState) {
       case GameState.ready:
-        return _buildReadyUI(context);
+        return _buildReadyUI(context, meta);
       case GameState.running:
-        return _buildRunningUI(context, game, lineProvider);
+        return _buildRunningUI(context, game, lineProvider, meta);
       case GameState.dead:
-        return _buildGameOverUI(context, game);
+        return _buildGameOverUI(context, game, meta);
       case GameState.result:
         return const SizedBox.shrink();
     }
   }
 
-  Widget _buildReadyUI(BuildContext context) {
+  Widget _buildReadyUI(BuildContext context, MetaProvider meta) {
     final textTheme = Theme.of(context).textTheme;
     return Positioned.fill(
       child: Container(
@@ -179,6 +249,24 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
                 ),
               ),
             ),
+            const SizedBox(height: 18),
+            _buildWalletBanner(context, meta),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: () {
+                _showSkinShop(context);
+              },
+              icon: const Icon(Icons.color_lens_rounded),
+              label: const Text('CUSTOMIZE'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: Colors.white,
+                side: BorderSide(color: Colors.white.withOpacity(0.4), width: 1.4),
+                padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(18),
+                ),
+              ),
+            ),
           ],
         ),
       ),
@@ -189,6 +277,7 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
     BuildContext context,
     GameProvider game,
     LineProvider lineProvider,
+    MetaProvider meta,
   ) {
     final textTheme = Theme.of(context).textTheme;
     return Positioned(
@@ -266,12 +355,15 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
               ],
             ),
           ),
+          const SizedBox(height: 12),
+          _buildWalletBanner(context, meta),
         ],
       ),
     );
   }
 
-  Widget _buildGameOverUI(BuildContext context, GameProvider game) {
+  Widget _buildGameOverUI(
+      BuildContext context, GameProvider game, MetaProvider meta) {
     final adProvider = context.watch<AdProvider>();
     final textTheme = Theme.of(context).textTheme;
     return Positioned.fill(
@@ -327,10 +419,15 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
                   alignment: WrapAlignment.center,
                   children: [
                     ElevatedButton.icon(
-                      onPressed: () {
-                        adProvider.showInterstitialAdIfNeeded();
-                        game.resetGame();
-                        game.startGame();
+                      onPressed: () async {
+                        await game.finalizeRun(metaProvider: meta);
+                        adProvider.maybeShowInterstitial(
+                          lastRunDuration: game.lastRunDuration,
+                          onClosed: () {
+                            game.resetGame();
+                            game.startGame();
+                          },
+                        );
                       },
                       icon: const Icon(Icons.refresh_rounded),
                       label: const Text('RESTART'),
@@ -365,7 +462,8 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
                 ),
                 const SizedBox(height: 16),
                 TextButton(
-                  onPressed: () {
+                  onPressed: () async {
+                    await game.finalizeRun(metaProvider: meta);
                     game.resetGame();
                   },
                   child: const Text('Return to menu'),
@@ -374,6 +472,262 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildWalletBanner(BuildContext context, MetaProvider meta) {
+    final textTheme = Theme.of(context).textTheme;
+    final walletText = meta.isReady ? '${meta.totalCoins}' : '…';
+    final equippedSkin = meta.isReady ? meta.selectedSkin.name : 'Loading';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+      decoration: BoxDecoration(
+        color: Colors.black.withOpacity(0.22),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: Colors.white.withOpacity(0.08)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.savings_rounded, color: Color(0xFFFACC15), size: 26),
+          const SizedBox(width: 12),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Wallet',
+                style: textTheme.bodySmall?.copyWith(
+                  color: Colors.white70,
+                  letterSpacing: 1.1,
+                ),
+              ),
+              Text(
+                walletText,
+                style: textTheme.titleMedium?.copyWith(
+                  color: Colors.white,
+                  fontSize: 20,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 18),
+          if (meta.isReady)
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Equipped',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: Colors.white70,
+                    letterSpacing: 1.1,
+                  ),
+                ),
+                Text(
+                  equippedSkin,
+                  style: textTheme.titleSmall?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSkinTile({
+    required BuildContext rootContext,
+    required MetaProvider meta,
+    required PlayerSkin skin,
+  }) {
+    final owned = meta.isSkinOwned(skin.id);
+    final selected = meta.selectedSkin.id == skin.id;
+    final theme = Theme.of(rootContext).textTheme;
+    final buttonLabel = selected
+        ? 'Equipped'
+        : owned
+            ? 'Equip'
+            : 'Unlock ${skin.cost}';
+    final Color backgroundColor;
+    final Color foregroundColor;
+    if (selected) {
+      backgroundColor = Colors.white24;
+      foregroundColor = Colors.white;
+    } else if (!owned) {
+      backgroundColor = const Color(0xFFF97316);
+      foregroundColor = Colors.black;
+    } else {
+      backgroundColor = const Color(0xFF38BDF8);
+      foregroundColor = Colors.white;
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.05),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: selected ? const Color(0xFF38BDF8) : Colors.white.withOpacity(0.08),
+          width: selected ? 2 : 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 54,
+            height: 54,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: LinearGradient(
+                colors: [skin.primaryColor, skin.secondaryColor],
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: skin.auraColor.withOpacity(0.45),
+                  blurRadius: 14,
+                  offset: const Offset(0, 6),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  skin.name,
+                  style: theme.titleMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  owned
+                      ? (selected ? 'Currently equipped' : 'Unlocked')
+                      : 'Cost: ${skin.cost} coins',
+                  style: theme.bodySmall?.copyWith(
+                    color: owned ? Colors.greenAccent : Colors.white70,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          ElevatedButton(
+            onPressed: selected
+                ? null
+                : () async {
+                    if (!owned) {
+                      final success = await meta.purchaseSkin(skin);
+                      if (!success) {
+                        ScaffoldMessenger.of(rootContext).showSnackBar(
+                          const SnackBar(
+                            content: Text('Not enough coins to unlock this skin.'),
+                            behavior: SnackBarBehavior.floating,
+                          ),
+                        );
+                        return;
+                      } else {
+                        ScaffoldMessenger.of(rootContext).showSnackBar(
+                          SnackBar(
+                            content: Text('${skin.name} unlocked!'),
+                            behavior: SnackBarBehavior.floating,
+                          ),
+                        );
+                      }
+                    }
+                    await meta.selectSkin(skin);
+                  },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: backgroundColor,
+              foregroundColor: foregroundColor,
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+              textStyle: theme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            child: Text(buttonLabel),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTutorialOverlay(BuildContext context, GameProvider game) {
+    if (game.gameState != GameState.running || !game.isTutorialActive) {
+      return const SizedBox.shrink();
+    }
+    return IgnorePointer(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Stack(
+          children: [
+            Positioned(
+              left: 0,
+              bottom: 140,
+              child: AnimatedOpacity(
+                opacity: game.showJumpHint ? 1 : 0,
+                duration: const Duration(milliseconds: 250),
+                child: _buildTutorialBubble(
+                  context: context,
+                  icon: Icons.touch_app_rounded,
+                  text: 'Tap left to jump!',
+                  alignment: CrossAxisAlignment.start,
+                ),
+              ),
+            ),
+            Positioned(
+              right: 0,
+              bottom: 140,
+              child: AnimatedOpacity(
+                opacity: game.showDrawHint ? 1 : 0,
+                duration: const Duration(milliseconds: 250),
+                child: _buildTutorialBubble(
+                  context: context,
+                  icon: Icons.gesture_rounded,
+                  text: 'Drag right to draw!',
+                  alignment: CrossAxisAlignment.end,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTutorialBubble({
+    required BuildContext context,
+    required IconData icon,
+    required String text,
+    required CrossAxisAlignment alignment,
+  }) {
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+      decoration: BoxDecoration(
+        color: Colors.black.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: Colors.white.withOpacity(0.2)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: alignment,
+        children: [
+          Icon(icon, color: Colors.white, size: 22),
+          const SizedBox(height: 8),
+          Text(
+            text,
+            style: textTheme.bodyMedium?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 1.05,
+            ),
+            textAlign:
+                alignment == CrossAxisAlignment.start ? TextAlign.left : TextAlign.right,
+          ),
+        ],
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'ad_provider.dart';
 import 'coin_provider.dart';
 import 'sound_provider.dart';
 import 'game_screen.dart';
+import 'meta_provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -76,6 +77,7 @@ class _GameScreenWrapperState extends State<GameScreenWrapper> with TickerProvid
     return MultiProvider(
       providers: [
         Provider(create: (_) => SoundProvider()), // Add SoundProvider
+        ChangeNotifierProvider(create: (_) => MetaProvider()),
         ChangeNotifierProvider(create: (_) => AdProvider()),
         ChangeNotifierProvider(create: (_) => LineProvider()),
         ChangeNotifierProvider(create: (_) => ObstacleProvider(gameWidth: gameWidth)),

--- a/lib/meta_provider.dart
+++ b/lib/meta_provider.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'player_skin.dart';
+
+class MetaProvider with ChangeNotifier {
+  MetaProvider() {
+    _loadFromStorage();
+  }
+
+  static const _coinsKey = 'meta_total_coins';
+  static const _ownedSkinsKey = 'meta_owned_skins';
+  static const _selectedSkinKey = 'meta_selected_skin';
+
+  final List<PlayerSkin> _skins = kDefaultSkins;
+  final Set<String> _ownedSkinIds = {'default'};
+
+  SharedPreferences? _prefs;
+  bool _initialized = false;
+  int _totalCoins = 0;
+  String _selectedSkinId = 'default';
+
+  bool get isReady => _initialized;
+  int get totalCoins => _totalCoins;
+  List<PlayerSkin> get skins => _skins;
+
+  PlayerSkin get selectedSkin =>
+      _skins.firstWhere((skin) => skin.id == _selectedSkinId,
+          orElse: () => _skins.first);
+
+  bool isSkinOwned(String skinId) => _ownedSkinIds.contains(skinId);
+
+  bool canAfford(PlayerSkin skin) => _totalCoins >= skin.cost;
+
+  Future<void> addCoins(int amount) async {
+    if (amount <= 0) return;
+    _totalCoins += amount;
+    await _saveCoins();
+    notifyListeners();
+  }
+
+  Future<bool> purchaseSkin(PlayerSkin skin) async {
+    if (_ownedSkinIds.contains(skin.id)) {
+      return true;
+    }
+    if (skin.cost > _totalCoins) {
+      return false;
+    }
+
+    _totalCoins -= skin.cost;
+    _ownedSkinIds.add(skin.id);
+    await _saveOwnedSkins();
+    await _saveCoins();
+    notifyListeners();
+    return true;
+  }
+
+  Future<void> selectSkin(PlayerSkin skin) async {
+    if (!_ownedSkinIds.contains(skin.id)) {
+      return;
+    }
+    _selectedSkinId = skin.id;
+    await _saveSelectedSkin();
+    notifyListeners();
+  }
+
+  Future<void> _loadFromStorage() async {
+    _prefs = await SharedPreferences.getInstance();
+    _totalCoins = _prefs?.getInt(_coinsKey) ?? 0;
+    final owned = _prefs?.getStringList(_ownedSkinsKey);
+    if (owned != null && owned.isNotEmpty) {
+      _ownedSkinIds
+        ..clear()
+        ..addAll(owned);
+    }
+    _ownedSkinIds.add('default');
+
+    final selected = _prefs?.getString(_selectedSkinKey);
+    if (selected != null && _ownedSkinIds.contains(selected)) {
+      _selectedSkinId = selected;
+    }
+
+    _initialized = true;
+    notifyListeners();
+  }
+
+  Future<void> _saveCoins() async {
+    final prefs = _prefs;
+    if (prefs != null) {
+      await prefs.setInt(_coinsKey, _totalCoins);
+    }
+  }
+
+  Future<void> _saveOwnedSkins() async {
+    final prefs = _prefs;
+    if (prefs != null) {
+      await prefs.setStringList(_ownedSkinsKey, _ownedSkinIds.toList());
+    }
+  }
+
+  Future<void> _saveSelectedSkin() async {
+    final prefs = _prefs;
+    if (prefs != null) {
+      await prefs.setString(_selectedSkinKey, _selectedSkinId);
+    }
+  }
+}

--- a/lib/player_skin.dart
+++ b/lib/player_skin.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// Describes a cosmetic skin for the player avatar.
+class PlayerSkin {
+  const PlayerSkin({
+    required this.id,
+    required this.name,
+    required this.cost,
+    required this.primaryColor,
+    required this.secondaryColor,
+    required this.auraColor,
+    required this.trailColor,
+  });
+
+  final String id;
+  final String name;
+  final int cost;
+  final Color primaryColor;
+  final Color secondaryColor;
+  final Color auraColor;
+  final Color trailColor;
+}
+
+/// Default catalog of skins available in the prototype store.
+const List<PlayerSkin> kDefaultSkins = [
+  PlayerSkin(
+    id: 'default',
+    name: 'Neon Runner',
+    cost: 0,
+    primaryColor: Color(0xFF38BDF8),
+    secondaryColor: Color(0xFF1D4ED8),
+    auraColor: Color(0xFF38BDF8),
+    trailColor: Color(0xFFA855F7),
+  ),
+  PlayerSkin(
+    id: 'ember',
+    name: 'Ember Trail',
+    cost: 100,
+    primaryColor: Color(0xFFF97316),
+    secondaryColor: Color(0xFFEA580C),
+    auraColor: Color(0xFFFF9B45),
+    trailColor: Color(0xFFFF5F70),
+  ),
+  PlayerSkin(
+    id: 'glacier',
+    name: 'Glacier Drift',
+    cost: 300,
+    primaryColor: Color(0xFF67E8F9),
+    secondaryColor: Color(0xFF0EA5E9),
+    auraColor: Color(0xFFBAE6FD),
+    trailColor: Color(0xFF60A5FA),
+  ),
+  PlayerSkin(
+    id: 'midnight',
+    name: 'Midnight Pulse',
+    cost: 800,
+    primaryColor: Color(0xFFA855F7),
+    secondaryColor: Color(0xFF7C3AED),
+    auraColor: Color(0xFFC084FC),
+    trailColor: Color(0xFF22D3EE),
+  ),
+];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   google_fonts: ^6.3.1
   google_mobile_ads: ^6.0.0
   provider: ^6.1.5+1
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add onboarding prompts, tutorial pacing, and obstacle spawning tweaks to reduce early frustration
- integrate an ink gauge HUD refresh, wallet banner, and cosmetic skin shop with shared_preferences-backed persistence
- refactor ad cadence and game loop feedback with haptics, ink resource management, and reward banking hooks

## Testing
- Not run (Flutter tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68c8a60232708327945f82a6c216f1c3