### PR TITLE
Integrate analytics and refresh visuals

### DIFF
--- a/lib/analytics_provider.dart
+++ b/lib/analytics_provider.dart
@@ -1,0 +1,89 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/foundation.dart';
+
+import 'game_models.dart';
+
+/// Lightweight wrapper around [FirebaseAnalytics] that exposes
+/// high-level logging helpers used across the game.
+class AnalyticsProvider {
+  AnalyticsProvider() : _analytics = FirebaseAnalytics.instance;
+
+  AnalyticsProvider.fake() : _analytics = null;
+
+  final FirebaseAnalytics? _analytics;
+
+  bool get isEnabled => _analytics != null;
+
+  Future<void> logGameStart({
+    required bool tutorialActive,
+    required int revivesUnlocked,
+    required double inkMultiplier,
+    required int totalCoins,
+    required bool missionsAvailable,
+  }) async {
+    await _logEvent('game_start', {
+      'tutorial_active': tutorialActive,
+      'revives_unlocked': revivesUnlocked,
+      'ink_multiplier': double.parse(inkMultiplier.toStringAsFixed(2)),
+      'total_coins': totalCoins,
+      'missions_available': missionsAvailable,
+    });
+  }
+
+  Future<void> logGameEnd({
+    required RunStats stats,
+    required int revivesUsed,
+    required int totalCoins,
+    required int missionsCompletedDelta,
+  }) async {
+    await _logEvent('game_end', {
+      'score': stats.score,
+      'duration_ms': stats.duration.inMilliseconds,
+      'coins_gained': stats.coins,
+      'jumps': stats.jumpsPerformed,
+      'draw_time_ms': stats.drawTimeMs,
+      'used_line': stats.usedLine,
+      'accident_death': stats.accidentDeath,
+      'revives_used': revivesUsed,
+      'missions_completed_delta': missionsCompletedDelta,
+      'total_coins': totalCoins,
+    });
+  }
+
+  Future<void> logCoinsCollected({
+    required int amount,
+    required int totalCoins,
+    String source = 'run',
+  }) async {
+    await _logEvent('coins_collected', {
+      'amount': amount,
+      'total_coins': totalCoins,
+      'source': source,
+    });
+  }
+
+  Future<void> logAdWatched({
+    required String placement,
+    required String adType,
+    required bool rewardEarned,
+  }) async {
+    await _logEvent('ad_watched', {
+      'placement': placement,
+      'ad_type': adType,
+      'reward_earned': rewardEarned,
+    });
+  }
+
+  Future<void> _logEvent(String name, Map<String, Object?> parameters) async {
+    final analytics = _analytics;
+    if (analytics == null) {
+      return;
+    }
+    try {
+      await analytics.logEvent(name: name, parameters: parameters);
+    } catch (error, stackTrace) {
+      debugPrint('Failed to log analytics event "$name": $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
+  }
+}

--- a/lib/drawing_painter.dart
+++ b/lib/drawing_painter.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -18,6 +19,8 @@ class DrawingPainter extends CustomPainter {
     required this.skin,
     required this.isRestWindow,
     required this.colorBlindFriendly,
+    required this.elapsedMs,
+    required this.scrollSpeed,
   });
 
   final Offset playerPosition;
@@ -27,6 +30,8 @@ class DrawingPainter extends CustomPainter {
   final PlayerSkin skin;
   final bool isRestWindow;
   final bool colorBlindFriendly;
+  final double elapsedMs;
+  final double scrollSpeed;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -39,129 +44,431 @@ class DrawingPainter extends CustomPainter {
   }
 
   void _drawBackground(Canvas canvas, Size size) {
-    final gradient = isRestWindow
-        ? const LinearGradient(
-            colors: [
-              Color(0xFF0F172A),
-              Color(0xFF1E3A8A),
-              Color(0xFF34D399),
-            ],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-          )
-        : const LinearGradient(
-            colors: [Color(0xFF0F172A), Color(0xFF1E293B), Color(0xFF38BDF8)],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-          );
-    final backgroundPaint = Paint()
+    final backgroundColors = isRestWindow
+        ? const [Color(0xFF02131E), Color(0xFF0F2A4E), Color(0xFF34D399)]
+        : const [Color(0xFF020617), Color(0xFF0B1220), Color(0xFF1D4ED8)];
+    final gradient = LinearGradient(
+      colors: backgroundColors,
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      stops: const [0.0, 0.45, 1.0],
+    );
+    final paint = Paint()
       ..shader = gradient.createShader(Rect.fromLTWH(0, 0, size.width, size.height));
-    canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), backgroundPaint);
+    canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), paint);
 
+    _drawAurora(canvas, size);
+    _drawStarfield(canvas, size);
+    _drawParallaxLayers(canvas, size);
+  }
+
+  void _drawStarfield(Canvas canvas, Size size) {
+    final double time = elapsedMs / 1000.0;
     final starPaint = Paint()
-      ..color = Colors.white.withOpacity(isRestWindow ? 0.15 : 0.25)
+      ..color = Colors.white.withOpacity(0.12 + 0.08 * math.sin(time * 2.2))
       ..strokeCap = StrokeCap.round
       ..strokeWidth = 2;
 
-    for (var i = 0; i < size.width; i += 90) {
-      final y = (i * 0.4) % (size.height * 0.5);
+    for (double x = 0; x < size.width + 140; x += 70) {
+      final double baseY = (x * 0.35 + time * 40) % (size.height * 0.6);
+      final double jitter = math.sin((x + time * 60) * 0.02) * 10;
       canvas.drawPoints(
         ui.PointMode.points,
-        [Offset(i + 20, y + 40), Offset(i + 60, (y + 120) % (size.height * 0.5) + 60)],
+        [
+          Offset((x + time * 50) % (size.width + 120), baseY + 40 + jitter),
+          Offset((x * 0.8 + 30) % (size.width + 120),
+              (baseY + 120) % (size.height * 0.6) + 80 - jitter),
+        ],
         starPaint,
       );
     }
   }
 
+  void _drawAurora(Canvas canvas, Size size) {
+    final palette = isRestWindow
+        ? const [Color(0xFF2DD4BF), Color(0xFF38BDF8), Color(0xFFA855F7)]
+        : const [Color(0xFF2563EB), Color(0xFF22D3EE), Color(0xFFF472B6)];
+    final double time = elapsedMs / 900.0;
+    for (var i = 0; i < 3; i++) {
+      final double phase = time + i * 0.65;
+      final double centerX =
+          size.width * (0.2 + i * 0.35) + math.sin(phase * 1.8) * 48;
+      final Rect rect = Rect.fromCenter(
+        center: Offset(centerX, size.height * 0.24 + math.sin(phase) * 18),
+        width: size.width * 0.55,
+        height: 160,
+      );
+      final auroraPaint = Paint()
+        ..shader = LinearGradient(
+          colors: [
+            palette[i % palette.length].withOpacity(0.0),
+            palette[i % palette.length].withOpacity(isRestWindow ? 0.45 : 0.35),
+            palette[(i + 1) % palette.length].withOpacity(0.0),
+          ],
+          begin: Alignment.bottomCenter,
+          end: Alignment.topCenter,
+        ).createShader(rect)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 45);
+      canvas.save();
+      canvas.translate(math.sin(phase) * 24, 0);
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(rect, const Radius.circular(80)),
+        auroraPaint,
+      );
+      canvas.restore();
+    }
+  }
+
+  void _drawParallaxLayers(Canvas canvas, Size size) {
+    final baseColor = isRestWindow ? const Color(0xFF0B3B33) : const Color(0xFF0B1120);
+    _drawParallaxBand(
+      canvas,
+      size,
+      baseHeight: size.height * 0.58,
+      amplitude: 24,
+      speed: scrollSpeed * 0.45 + 18,
+      color: baseColor.withOpacity(0.65),
+    );
+    _drawParallaxBand(
+      canvas,
+      size,
+      baseHeight: size.height * 0.66,
+      amplitude: 32,
+      speed: scrollSpeed * 0.6 + 26,
+      color: baseColor.withOpacity(0.5),
+    );
+  }
+
+  void _drawParallaxBand(
+    Canvas canvas,
+    Size size, {
+    required double baseHeight,
+    required double amplitude,
+    required double speed,
+    required Color color,
+  }) {
+    final double width = size.width;
+    const double step = 140;
+    final double time = elapsedMs / 1000.0;
+    final double offset = -(time * speed) % step;
+    final path = Path()
+      ..moveTo(-step, size.height)
+      ..lineTo(-step, baseHeight);
+    for (double x = -step; x <= width + step; x += step) {
+      final double controlX = x + step / 2;
+      final double controlY =
+          baseHeight - math.sin((x + time * speed * 5) * 0.015) * amplitude;
+      final double nextX = x + step;
+      final double nextY =
+          baseHeight - math.sin((nextX + time * speed * 5) * 0.015) * amplitude;
+      path.quadraticBezierTo(controlX, controlY, nextX, nextY);
+    }
+    path
+      ..lineTo(width + step, size.height)
+      ..close();
+    final paint = Paint()..color = color;
+    canvas.save();
+    canvas.translate(offset, 0);
+    canvas.drawPath(path, paint);
+    canvas.restore();
+  }
+
   void _drawGround(Canvas canvas, Size size) {
-    const groundTop = 400.0;
+    const double groundTop = 400.0;
     final groundRect = Rect.fromLTWH(0, groundTop, size.width, size.height - groundTop);
     final groundGradient = isRestWindow
         ? const LinearGradient(
-            colors: [Color(0xFF15803D), Color(0xFF22C55E)],
+            colors: [Color(0xFF0F4E3B), Color(0xFF22C55E), Color(0xFFA7F3D0)],
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
           )
         : const LinearGradient(
-            colors: [Color(0xFF0F766E), Color(0xFF047857)],
+            colors: [Color(0xFF0F172A), Color(0xFF0F766E), Color(0xFF22D3EE)],
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
           );
-    final groundPaint = Paint()..shader = groundGradient.createShader(groundRect);
-    canvas.drawRect(groundRect, groundPaint);
+    final paint = Paint()..shader = groundGradient.createShader(groundRect);
+    canvas.drawRect(groundRect, paint);
 
-    final gridPaint = Paint()
-      ..color = Colors.black.withOpacity(0.08)
-      ..strokeWidth = 1;
-    for (var x = 0.0; x < size.width; x += 40) {
-      canvas.drawLine(Offset(x, groundTop), Offset(x + 20, groundTop + 16), gridPaint);
+    final highlightPaint = Paint()
+      ..shader = LinearGradient(
+        colors: [
+          Colors.white.withOpacity(0.14),
+          Colors.white.withOpacity(0.0),
+        ],
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+      ).createShader(groundRect);
+    canvas.drawRect(groundRect, highlightPaint);
+
+    final double stripeSpacing = 80;
+    final double offset =
+        (elapsedMs * (scrollSpeed * 0.25 + 20) / 1000) % stripeSpacing;
+    final stripePaint = Paint()
+      ..color = Colors.white.withOpacity(0.08)
+      ..strokeWidth = 4
+      ..strokeCap = StrokeCap.round;
+    for (double x = -stripeSpacing; x < size.width + stripeSpacing; x += stripeSpacing) {
+      final double startX = x + offset;
+      canvas.drawLine(
+        Offset(startX, groundTop + 18),
+        Offset(startX + 26, groundTop + 92),
+        stripePaint,
+      );
     }
+
+    final horizonPaint = Paint()
+      ..shader = LinearGradient(
+        colors: [
+          const Color(0xFF38BDF8).withOpacity(0.35),
+          Colors.transparent,
+        ],
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+      ).createShader(Rect.fromLTWH(0, groundTop - 12, size.width, 24));
+    canvas.drawRect(Rect.fromLTWH(0, groundTop - 12, size.width, 24), horizonPaint);
   }
 
   void _drawPlayer(Canvas canvas) {
-    const double radius = 20;
-    final playerRect = Rect.fromCircle(center: playerPosition, radius: radius);
-    final playerPaint = Paint()
-      ..shader = RadialGradient(
-        colors: [skin.primaryColor, skin.secondaryColor],
-        center: Alignment.topLeft,
-        radius: 1.2,
-      ).createShader(playerRect);
-    canvas.drawCircle(playerPosition, radius, playerPaint);
+    final double time = elapsedMs / 1000.0;
+    final bool airborne = playerPosition.dy < 379;
+    final double phase = time * (airborne ? 8.0 : 6.0);
+    final double bob = airborne ? -6 + math.sin(phase) * 2 : math.sin(phase) * 3;
+    final Offset center = playerPosition.translate(0, bob);
 
     final auraPaint = Paint()
-      ..color = skin.auraColor.withOpacity(0.35)
-      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 12);
-    canvas.drawCircle(playerPosition, radius + 12, auraPaint);
+      ..color = skin.auraColor.withOpacity(0.32)
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 18);
+    canvas.drawCircle(center, 34, auraPaint);
+
+    final bodyRect = Rect.fromCenter(center: center.translate(0, -2), width: 36, height: 46);
+    final bodyPaint = Paint()
+      ..shader = LinearGradient(
+        colors: [skin.primaryColor, skin.secondaryColor],
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+      ).createShader(bodyRect);
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(bodyRect, const Radius.circular(14)),
+      bodyPaint,
+    );
+
+    final chestRect = Rect.fromCenter(center: center.translate(0, 6), width: 28, height: 22);
+    final chestPaint = Paint()
+      ..shader = LinearGradient(
+        colors: [
+          Colors.white.withOpacity(0.3),
+          Colors.white.withOpacity(0.0),
+        ],
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+      ).createShader(chestRect);
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(chestRect, const Radius.circular(10)),
+      chestPaint,
+    );
+
+    final headCenter = center.translate(0, -28);
+    final headRect = Rect.fromCircle(center: headCenter, radius: 14);
+    final headPaint = Paint()
+      ..shader = RadialGradient(
+        colors: [Colors.white, skin.primaryColor.withOpacity(0.85)],
+        center: Alignment.topCenter,
+        radius: 0.9,
+      ).createShader(headRect);
+    canvas.drawOval(headRect, headPaint);
+
+    final visorRect = Rect.fromLTWH(headCenter.dx - 10, headCenter.dy - 6, 20, 10);
+    final visorPaint = Paint()
+      ..shader = LinearGradient(
+        colors: [
+          skin.secondaryColor.withOpacity(0.95),
+          Colors.white.withOpacity(0.65),
+        ],
+        begin: Alignment.centerLeft,
+        end: Alignment.centerRight,
+      ).createShader(visorRect);
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(visorRect, const Radius.circular(6)),
+      visorPaint,
+    );
+
+    final eyePaint = Paint()..color = Colors.black87;
+    final double eyeShift = math.sin(phase) * 1.5;
+    canvas.drawCircle(headCenter.translate(-5 + eyeShift, -2), 2.4, eyePaint);
+    canvas.drawCircle(headCenter.translate(5 + eyeShift, -2), 2.4, eyePaint);
+
+    final double legSwing = airborne ? -0.3 : math.sin(phase) * 0.8;
+    final double legOppSwing = airborne ? 0.45 : math.sin(phase + math.pi) * 0.8;
+    _drawLimb(
+      canvas,
+      origin: center.translate(-8, 18),
+      length: 28,
+      angle: legSwing,
+      thickness: 6,
+      color: skin.secondaryColor.withOpacity(0.9),
+    );
+    _drawLimb(
+      canvas,
+      origin: center.translate(8, 18),
+      length: 28,
+      angle: legOppSwing,
+      thickness: 6,
+      color: skin.primaryColor.withOpacity(0.9),
+    );
+
+    final double armSwing = airborne ? -0.25 : math.sin(phase + math.pi / 2) * 0.6;
+    final double armOppSwing = airborne ? 0.32 : math.sin(phase + math.pi / 2 + math.pi) * 0.6;
+    _drawLimb(
+      canvas,
+      origin: center.translate(-13, -4),
+      length: 24,
+      angle: armSwing,
+      thickness: 5,
+      color: skin.secondaryColor.withOpacity(0.85),
+      rounded: true,
+    );
+    _drawLimb(
+      canvas,
+      origin: center.translate(13, -4),
+      length: 24,
+      angle: armOppSwing,
+      thickness: 5,
+      color: skin.primaryColor.withOpacity(0.85),
+      rounded: true,
+    );
+
+    final thrusterRect = Rect.fromLTWH(center.dx - 8, center.dy + 12, 16, 30);
+    final thrusterPaint = Paint()
+      ..shader = LinearGradient(
+        colors: [
+          skin.trailColor.withOpacity(airborne ? 0.6 : 0.35),
+          Colors.transparent,
+        ],
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+      ).createShader(thrusterRect)
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 20);
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(thrusterRect, const Radius.circular(8)),
+      thrusterPaint,
+    );
+  }
+
+  void _drawLimb(
+    Canvas canvas, {
+    required Offset origin,
+    required double length,
+    required double angle,
+    required double thickness,
+    required Color color,
+    bool rounded = false,
+  }) {
+    canvas.save();
+    canvas.translate(origin.dx, origin.dy);
+    canvas.rotate(angle);
+    final rect = Rect.fromLTWH(-thickness / 2, 0, thickness, length);
+    final paint = Paint()
+      ..shader = LinearGradient(
+        colors: [
+          color,
+          Color.lerp(color, Colors.black, 0.25)!,
+        ],
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+      ).createShader(rect);
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        rect,
+        Radius.circular(rounded ? thickness : thickness * 0.6),
+      ),
+      paint,
+    );
+    canvas.restore();
   }
 
   void _drawObstacles(Canvas canvas) {
     for (final obstacle in obstacles) {
       final rect = Rect.fromLTWH(obstacle.x, obstacle.y, obstacle.width, obstacle.height);
+      final rrect = RRect.fromRectAndRadius(rect, const Radius.circular(10));
       final colors = colorBlindFriendly
           ? const [Color(0xFFEAB308), Color(0xFFB45309)]
           : const [Color(0xFFFB7185), Color(0xFFF43F5E)];
-      final paint = Paint()
+      final bodyPaint = Paint()
         ..shader = LinearGradient(
-          colors: colors,
+          colors: [colors.first, Color.lerp(colors.last, Colors.black, 0.2)!],
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
         ).createShader(rect);
-      final rrect = RRect.fromRectAndRadius(rect, const Radius.circular(8));
-      canvas.drawRRect(rrect, paint);
+      canvas.drawRRect(rrect, bodyPaint);
 
-      final highlight = Paint()
-        ..color = Colors.white.withOpacity(colorBlindFriendly ? 0.3 : 0.25)
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 2;
-      canvas.drawRRect(rrect.deflate(3), highlight);
+      final shinePaint = Paint()
+        ..shader = LinearGradient(
+          colors: [
+            Colors.white.withOpacity(0.4),
+            Colors.white.withOpacity(0.0),
+          ],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ).createShader(rect.deflate(2));
+      canvas.drawRRect(rrect.deflate(2), shinePaint);
+
+      final spikes = Path()..moveTo(rect.left, rect.top);
+      final int segments = math.max(1, (rect.width / 12).floor());
+      final double step = rect.width / segments;
+      for (int i = 0; i < segments; i++) {
+        final double x = rect.left + i * step;
+        spikes
+          ..lineTo(x + step / 2, rect.top - 10)
+          ..lineTo(x + step, rect.top);
+      }
+      spikes.close();
+      final spikePaint = Paint()
+        ..shader = LinearGradient(
+          colors: [
+            Colors.white.withOpacity(colorBlindFriendly ? 0.55 : 0.4),
+            colors.first.withOpacity(0.55),
+          ],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ).createShader(Rect.fromLTWH(rect.left, rect.top - 10, rect.width, 12));
+      canvas.drawPath(spikes, spikePaint);
+
+      final glowPaint = Paint()
+        ..color = (colorBlindFriendly ? const Color(0xFFEAB308) : const Color(0xFFF43F5E))
+            .withOpacity(0.25)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.outer, 18);
+      canvas.drawRRect(rrect.inflate(4), glowPaint);
     }
   }
 
   void _drawCoins(Canvas canvas) {
+    final double time = elapsedMs / 1000.0;
     for (final coin in coins) {
       final coinRect = Rect.fromCircle(center: coin.position, radius: coin.radius);
-      final paint = Paint()
+      final basePaint = Paint()
         ..shader = const RadialGradient(
           colors: [Color(0xFFFEF08A), Color(0xFFFACC15), Color(0xFFCA8A04)],
           center: Alignment.topLeft,
         ).createShader(coinRect);
-      canvas.drawCircle(coin.position, coin.radius, paint);
+      canvas.drawCircle(coin.position, coin.radius, basePaint);
+
+      final twinkle = 0.5 + 0.5 * math.sin((coin.position.dx + time * 120) * 0.05);
+      final haloPaint = Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2
+        ..color = Colors.white.withOpacity(0.25 + 0.35 * twinkle);
+      canvas.drawCircle(coin.position, coin.radius + 3, haloPaint);
 
       final sparkle = Paint()
-        ..color = Colors.white.withOpacity(0.7)
+        ..color = Colors.white.withOpacity(0.6 + 0.3 * twinkle)
         ..strokeWidth = 2
         ..strokeCap = StrokeCap.round;
-      canvas.drawLine(
-        coin.position + const Offset(-4, -4),
-        coin.position + const Offset(4, 4),
-        sparkle,
-      );
-      canvas.drawLine(
-        coin.position + const Offset(-4, 4),
-        coin.position + const Offset(4, -4),
-        sparkle,
-      );
+      final double angle = time * 6 + coin.position.dx * 0.05;
+      final Offset dir = Offset(math.cos(angle), math.sin(angle));
+      final Offset ortho = Offset(-dir.dy, dir.dx);
+      canvas.drawLine(coin.position - dir * 4, coin.position + dir * 4, sparkle);
+      canvas.drawLine(coin.position - ortho * 3, coin.position + ortho * 3, sparkle);
     }
   }
 

--- a/lib/game_screen.dart
+++ b/lib/game_screen.dart
@@ -523,6 +523,7 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
     }
     final sound = context.read<SoundProvider>();
     adProvider.showRewardAd(
+      placement: 'gacha',
       onReward: () {
         meta.pullGacha(viaAd: true).then((result) {
           if (!mounted) return;
@@ -724,6 +725,8 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
                                   skin: metaProvider.selectedSkin,
                                   isRestWindow: game.isRestWindow,
                                   colorBlindFriendly: metaProvider.colorBlindMode,
+                                  elapsedMs: game.elapsedRunMs,
+                                  scrollSpeed: obstacleProvider.speed,
                                 ),
                               );
                             },
@@ -1079,6 +1082,7 @@ class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
                         onPressed: () {
                           final sound = context.read<SoundProvider>();
                           adProvider.showRewardAd(
+                            placement: 'revive',
                             onReward: () {
                               game.revivePlayer();
                             },

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,11 +7,16 @@
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:myapp/analytics_provider.dart';
 import 'package:myapp/main.dart';
 
 void main() {
   testWidgets('renders the Quick Draw Dash start screen', (tester) async {
-    await tester.pumpWidget(const QuickDrawDashApp());
+    await tester.pumpWidget(
+      QuickDrawDashApp(
+        analytics: AnalyticsProvider.fake(),
+      ),
+    );
 
     expect(find.text('Quick Draw Dash'), findsOneWidget);
     expect(find.text('START RUN'), findsOneWidget);


### PR DESCRIPTION
## Summary
- add an AnalyticsProvider wrapper and initialise Firebase so gameplay events can be logged safely
- hook game and ad flows into analytics, including game start/end, coins collected, and rewarded/interstitial exposures
- replace the circular avatar with an animated sprite and expand the background/obstacle/coin artwork for the Phase 5 visual polish

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c3fbb7588327abb1162f3039a14f