### PR TITLE
Implement control, monetization, and remote tuning upgrades

### DIFF
--- a/lib/drawing_painter.dart
+++ b/lib/drawing_painter.dart
@@ -21,6 +21,8 @@ class DrawingPainter extends CustomPainter {
     required this.colorBlindFriendly,
     required this.elapsedMs,
     required this.scrollSpeed,
+    required this.frameId,
+    required this.lineSignature,
   });
 
   final Offset playerPosition;
@@ -32,6 +34,14 @@ class DrawingPainter extends CustomPainter {
   final bool colorBlindFriendly;
   final double elapsedMs;
   final double scrollSpeed;
+  final int frameId;
+  final int lineSignature;
+  final Paint _coinHaloPaint =
+      Paint()..style = PaintingStyle.stroke..strokeWidth = 2;
+  final Paint _coinSparklePaint =
+      Paint()..style = PaintingStyle.stroke..strokeWidth = 2..strokeCap = StrokeCap.round;
+  final Paint _lineStrokePaint =
+      Paint()..strokeCap = StrokeCap.round..strokeJoin = StrokeJoin.round..strokeWidth = 8;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -454,21 +464,15 @@ class DrawingPainter extends CustomPainter {
       canvas.drawCircle(coin.position, coin.radius, basePaint);
 
       final twinkle = 0.5 + 0.5 * math.sin((coin.position.dx + time * 120) * 0.05);
-      final haloPaint = Paint()
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 2
-        ..color = Colors.white.withOpacity(0.25 + 0.35 * twinkle);
-      canvas.drawCircle(coin.position, coin.radius + 3, haloPaint);
+      _coinHaloPaint.color = Colors.white.withOpacity(0.25 + 0.35 * twinkle);
+      canvas.drawCircle(coin.position, coin.radius + 3, _coinHaloPaint);
 
-      final sparkle = Paint()
-        ..color = Colors.white.withOpacity(0.6 + 0.3 * twinkle)
-        ..strokeWidth = 2
-        ..strokeCap = StrokeCap.round;
+      _coinSparklePaint.color = Colors.white.withOpacity(0.6 + 0.3 * twinkle);
       final double angle = time * 6 + coin.position.dx * 0.05;
       final Offset dir = Offset(math.cos(angle), math.sin(angle));
       final Offset ortho = Offset(-dir.dy, dir.dx);
-      canvas.drawLine(coin.position - dir * 4, coin.position + dir * 4, sparkle);
-      canvas.drawLine(coin.position - ortho * 3, coin.position + ortho * 3, sparkle);
+      canvas.drawLine(coin.position - dir * 4, coin.position + dir * 4, _coinSparklePaint);
+      canvas.drawLine(coin.position - ortho * 3, coin.position + ortho * 3, _coinSparklePaint);
     }
   }
 
@@ -490,19 +494,23 @@ class DrawingPainter extends CustomPainter {
       final age = now.difference(line.creationTime);
       final t = (1 - age.inMilliseconds / LineProvider.lineLifetime.inMilliseconds)
           .clamp(0.0, 1.0);
-      final paint = Paint()
+      _lineStrokePaint
         ..color = skin.trailColor.withOpacity(t)
-        ..strokeCap = StrokeCap.round
-        ..strokeJoin = StrokeJoin.round
-        ..strokeWidth = 8
         ..style = PaintingStyle.stroke;
 
-      canvas.drawPath(path, paint);
+      canvas.drawPath(path, _lineStrokePaint);
     }
   }
 
   @override
   bool shouldRepaint(covariant DrawingPainter oldDelegate) {
-    return true;
+    return frameId != oldDelegate.frameId ||
+        lineSignature != oldDelegate.lineSignature ||
+        isRestWindow != oldDelegate.isRestWindow ||
+        colorBlindFriendly != oldDelegate.colorBlindFriendly ||
+        skin.id != oldDelegate.skin.id ||
+        obstacles.length != oldDelegate.obstacles.length ||
+        coins.length != oldDelegate.coins.length ||
+        playerPosition != oldDelegate.playerPosition;
   }
 }

--- a/lib/game_models.dart
+++ b/lib/game_models.dart
@@ -157,3 +157,86 @@ class UpgradeSnapshot {
   final int maxRevives;
   final double coyoteBonusMs;
 }
+
+class DifficultyRemoteConfig {
+  const DifficultyRemoteConfig({
+    required this.baseSpeedMultiplier,
+    required this.speedRampIntervalScore,
+    required this.speedRampIncrease,
+    required this.maxSpeedMultiplier,
+    required this.targetSessionSeconds,
+    required this.tutorialSafeWindowMs,
+    required this.emergencyInkFloor,
+  });
+
+  final double baseSpeedMultiplier;
+  final int speedRampIntervalScore;
+  final double speedRampIncrease;
+  final double maxSpeedMultiplier;
+  final int targetSessionSeconds;
+  final int tutorialSafeWindowMs;
+  final double emergencyInkFloor;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'baseSpeedMultiplier': baseSpeedMultiplier,
+      'speedRampIntervalScore': speedRampIntervalScore,
+      'speedRampIncrease': speedRampIncrease,
+      'maxSpeedMultiplier': maxSpeedMultiplier,
+      'targetSessionSeconds': targetSessionSeconds,
+      'tutorialSafeWindowMs': tutorialSafeWindowMs,
+      'emergencyInkFloor': emergencyInkFloor,
+    };
+  }
+
+  static DifficultyRemoteConfig fromJson(String source) {
+    if (source.isEmpty) {
+      return const DifficultyRemoteConfig(
+        baseSpeedMultiplier: 1.0,
+        speedRampIntervalScore: 380,
+        speedRampIncrease: 0.35,
+        maxSpeedMultiplier: 2.2,
+        targetSessionSeconds: 50,
+        tutorialSafeWindowMs: 30000,
+        emergencyInkFloor: 14,
+      );
+    }
+    final map = json.decode(source) as Map<String, dynamic>;
+    return DifficultyRemoteConfig(
+      baseSpeedMultiplier:
+          (map['baseSpeedMultiplier'] as num?)?.toDouble() ?? 1.0,
+      speedRampIntervalScore: map['speedRampIntervalScore'] as int? ?? 380,
+      speedRampIncrease: (map['speedRampIncrease'] as num?)?.toDouble() ?? 0.35,
+      maxSpeedMultiplier: (map['maxSpeedMultiplier'] as num?)?.toDouble() ?? 2.2,
+      targetSessionSeconds: map['targetSessionSeconds'] as int? ?? 50,
+      tutorialSafeWindowMs: map['tutorialSafeWindowMs'] as int? ?? 30000,
+      emergencyInkFloor: (map['emergencyInkFloor'] as num?)?.toDouble() ?? 14,
+    );
+  }
+}
+
+class GameToast {
+  const GameToast({
+    required this.message,
+    required this.icon,
+    required this.color,
+    this.duration = const Duration(seconds: 2),
+  });
+
+  final String message;
+  final IconData icon;
+  final Color color;
+  final Duration duration;
+}
+
+class RunBoost {
+  const RunBoost({
+    required this.coinMultiplier,
+    required this.inkRegenMultiplier,
+    required this.duration,
+  });
+
+  final double coinMultiplier;
+  final double inkRegenMultiplier;
+  final Duration duration;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'line_provider.dart';
 import 'meta_provider.dart';
 import 'obstacle_provider.dart';
 import 'sound_provider.dart';
+import 'remote_config_provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -98,14 +99,17 @@ class _GameScreenWrapperState extends State<GameScreenWrapper> with TickerProvid
       providers: [
         Provider(create: (_) => SoundProvider()), // Add SoundProvider
         ChangeNotifierProvider(create: (_) => MetaProvider()),
-        ChangeNotifierProvider(
+        ChangeNotifierProvider(create: (_) => RemoteConfigProvider()),
+        ChangeNotifierProxyProvider<RemoteConfigProvider, AdProvider>(
           create: (context) =>
               AdProvider(analytics: context.read<AnalyticsProvider>()),
+          update: (_, remote, ad) => ad!..applyRemoteConfig(remote.adConfig),
         ),
         ChangeNotifierProvider(create: (_) => LineProvider()),
         ChangeNotifierProvider(create: (_) => ObstacleProvider(gameWidth: gameWidth)),
         ChangeNotifierProvider(create: (_) => CoinProvider()),
-        ChangeNotifierProxyProvider5<AdProvider, LineProvider, ObstacleProvider, CoinProvider, MetaProvider, GameProvider>(
+        ChangeNotifierProxyProvider6<AdProvider, LineProvider, ObstacleProvider,
+            CoinProvider, MetaProvider, RemoteConfigProvider, GameProvider>(
           create: (context) => GameProvider(
             analytics: context.read<AnalyticsProvider>(),
             adProvider: context.read<AdProvider>(),
@@ -113,11 +117,12 @@ class _GameScreenWrapperState extends State<GameScreenWrapper> with TickerProvid
             obstacleProvider: context.read<ObstacleProvider>(),
             coinProvider: context.read<CoinProvider>(),
             metaProvider: context.read<MetaProvider>(),
+            remoteConfigProvider: context.read<RemoteConfigProvider>(),
             soundProvider: context.read<SoundProvider>(),
             vsync: this,
           ),
-          update: (_, ad, line, obstacle, coin, meta, game) =>
-              game!..updateDependencies(ad, line, obstacle, coin, meta),
+          update: (_, ad, line, obstacle, coin, meta, remote, game) => game!
+            ..updateDependencies(ad, line, obstacle, coin, meta, remote),
         ),
       ],
       child: const GameScreen(),

--- a/lib/remote_config_provider.dart
+++ b/lib/remote_config_provider.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:flutter/foundation.dart';
+
+import 'game_models.dart';
+
+class RemoteConfigProvider with ChangeNotifier {
+  RemoteConfigProvider() {
+    _init();
+  }
+
+  final FirebaseRemoteConfig _remoteConfig = FirebaseRemoteConfig.instance;
+
+  DifficultyRemoteConfig _difficulty = const DifficultyRemoteConfig(
+    baseSpeedMultiplier: 1.0,
+    speedRampIntervalScore: 380,
+    speedRampIncrease: 0.35,
+    maxSpeedMultiplier: 2.2,
+    targetSessionSeconds: 50,
+    tutorialSafeWindowMs: 30000,
+    emergencyInkFloor: 14,
+  );
+  AdRemoteConfig _adConfig = const AdRemoteConfig(
+    interstitialCooldown: Duration(seconds: 90),
+    minimumRunDuration: Duration(seconds: 22),
+    minimumRunsBeforeInterstitial: 2,
+  );
+  bool _isReady = false;
+
+  bool get isReady => _isReady;
+  DifficultyRemoteConfig get difficulty => _difficulty;
+  AdRemoteConfig get adConfig => _adConfig;
+
+  Future<void> _init() async {
+    try {
+      await _remoteConfig.setConfigSettings(RemoteConfigSettings(
+        fetchTimeout: const Duration(seconds: 5),
+        minimumFetchInterval: const Duration(minutes: 30),
+      ));
+      await _remoteConfig.setDefaults(<String, Object>{
+        'difficulty_config': json.encode(_difficulty.toJson()),
+        'ad_config': json.encode(_adConfig.toJson()),
+      });
+      await _remoteConfig.fetchAndActivate();
+      _difficulty = DifficultyRemoteConfig.fromJson(
+        _remoteConfig.getString('difficulty_config'),
+      );
+      _adConfig = AdRemoteConfig.fromJson(
+        _remoteConfig.getString('ad_config'),
+      );
+      _isReady = true;
+      notifyListeners();
+    } catch (error, stackTrace) {
+      debugPrint('Remote config fetch failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      _isReady = true;
+      notifyListeners();
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   audioplayers: ^6.5.1
   firebase_analytics: ^12.0.1
   firebase_core: ^4.1.0
+  firebase_remote_config: ^5.1.3
   flutter:
     sdk: flutter
   google_fonts: ^6.3.1


### PR DESCRIPTION
## Summary
- add Firebase Remote Config driven tuning for ads and difficulty along with emergency ink safety and dynamic HUD messaging
- introduce one-tap control mode, tutorial safety tweaks, score bonus rewards, and ad-driven run boosts with refreshed ready/result UI
- optimize rendering and providers via split notifiers, cached paints, line signatures, and obstacle intro adjustments for smoother play

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8cb5dff3483279174cadce83355c4