### PR TITLE
Set Android NDK version to 27.0.12077973

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -19,7 +19,8 @@ android {
     namespace = "com.quickdrawdash.app"
     compileSdk = flutter.compileSdkVersion
 
-    ndkVersion = flutter.ndkVersion
+    // Force the Android NDK version required by audioplayers_android.
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- set the Android NDK version to 27.0.12077973 in the app Gradle build script to match plugin requirements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca84d6868c83279c08d55ee3baf8bf