### PR TITLE
Fix bootstrap zone init and improve ad/game readiness

### DIFF
--- a/test/providers/game_provider_test.dart
+++ b/test/providers/game_provider_test.dart
@@ -115,6 +115,8 @@ Future<GameProvider> _createGameProvider({
     vsync: const TestVSync(),
   );
 
+  await provider.waitUntilReady();
+
   if (runs.isNotEmpty) {
     provider.setRecentRunsForTesting(runs);
   }


### PR DESCRIPTION
## Summary
- ensure Flutter initialization runs in the same guarded zone as runApp and improve bootstrap logging fallback
- harden AdManager by waiting for Mobile Ads adapters, gating load calls until the SDK is ready, and retrying initialization safely
- add dependency readiness tracking to GameProvider, expose a readiness future, clean up listeners on dispose, and optimize the performance monitor computations
- update provider tests to await the new readiness hook

## Testing
- `flutter test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca982db494832787b1d5bcac3d6e03