### PR TITLE
Fix duplicate dispose overrides in game engine

### DIFF
--- a/lib/game/engine/game_engine.dart
+++ b/lib/game/engine/game_engine.dart
@@ -1098,17 +1098,6 @@ class GameProvider with ChangeNotifier {
     }
   }
 
-  // リソースの解放
-  @override
-  void dispose() {
-    _ticker?.dispose();
-    _toastTimer?.cancel();
-    _performanceMonitor.dispose();
-    _batteryOptimizer.dispose();
-    _errorRecoveryManager.dispose();
-    super.dispose();
-  }
-
   // Called by ChangeNotifierProxyProvider when dependencies change.
   void updateDependencies(
     AdManager ad,
@@ -1233,8 +1222,8 @@ class GameProvider with ChangeNotifier {
     _toastNotifier.dispose();
     metaProvider.removeListener(_dependencyListener);
     remoteConfigProvider.removeListener(_dependencyListener);
-    _performanceMonitor.stopMonitoring();
-    _batteryOptimizer.stopOptimization();
+    _performanceMonitor.dispose();
+    _batteryOptimizer.dispose();
     _errorRecoveryManager.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
- remove the duplicate `dispose` override in `GameProvider`
- consolidate cleanup so listeners, notifiers, and optimization subsystems are disposed in one place

## Testing
- Not run (flutter and dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca9ef9b6408327b4f9a0b49e47854a