### PR TITLE
Add chunk prefab spawner for procedural levels

### DIFF
--- a/lib/game/content/pcg/chunk_models.dart
+++ b/lib/game/content/pcg/chunk_models.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/content_models.dart';
+
+/// Canonical connector profiles used to attach chunk prefabs together.
+///
+/// The profiles describe the relative elevation of the entry/exit interface
+/// so that different chunks can be joined without creating impossible gaps or
+/// steps. `any` can connect to any other profile and is primarily used for
+/// special transition pieces.
+class ChunkProfiles {
+  ChunkProfiles._();
+
+  static const String any = 'any';
+  static const String start = 'start';
+  static const String ground = 'ground';
+  static const String low = 'low';
+  static const String mid = 'mid';
+  static const String high = 'high';
+}
+
+/// Endpoint descriptor for the entry or exit of a chunk prefab.
+class ChunkEndpoint {
+  const ChunkEndpoint({
+    required this.profile,
+    required this.height,
+  }) : assert(height.isFinite, 'Endpoint height must be finite');
+
+  /// Canonical profile identifier. See [ChunkProfiles] for recommended values.
+  final String profile;
+
+  /// Physical height (in game units) relative to the baseline ground level.
+  final double height;
+
+  /// Returns `true` when this endpoint can connect with [other] while obeying
+  /// the provided [maxHeightDelta] tolerance.
+  bool isCompatibleWith(
+    ChunkEndpoint other, {
+    double maxHeightDelta = 40,
+  }) {
+    final profileMatches = profile == ChunkProfiles.any ||
+        other.profile == ChunkProfiles.any ||
+        profile == other.profile;
+    if (!profileMatches) {
+      return false;
+    }
+    return (height - other.height).abs() <= maxHeightDelta;
+  }
+
+  ChunkEndpoint copyWith({String? profile, double? height}) {
+    return ChunkEndpoint(
+      profile: profile ?? this.profile,
+      height: height ?? this.height,
+    );
+  }
+}
+
+/// Base class for elements contained within a prefab chunk.
+@immutable
+abstract class ChunkElement {
+  const ChunkElement();
+}
+
+/// Platform geometry spawned as part of a chunk.
+class PlatformElement extends ChunkElement {
+  const PlatformElement({
+    required this.startX,
+    required this.endX,
+    required this.height,
+    this.type = 'platform',
+  })  : assert(startX.isFinite),
+        assert(endX.isFinite),
+        assert(height.isFinite),
+        assert(endX >= startX, 'endX must be greater than startX');
+
+  final double startX;
+  final double endX;
+  final double height;
+  final String type;
+}
+
+/// Obstacle spawn marker for the chunk.
+class ObstacleElement extends ChunkElement {
+  const ObstacleElement({
+    required this.positionX,
+    required this.height,
+    this.obstacleType = 'standard',
+  })  : assert(positionX.isFinite),
+        assert(height.isFinite);
+
+  final double positionX;
+  final double height;
+  final String obstacleType;
+}
+
+/// Collectible spawn marker for the chunk.
+class CollectibleElement extends ChunkElement {
+  const CollectibleElement({
+    required this.positionX,
+    required this.height,
+    this.rewardType = 'coin',
+  })  : assert(positionX.isFinite),
+        assert(height.isFinite);
+
+  final double positionX;
+  final double height;
+  final String rewardType;
+}
+
+/// Difficulty band supported by a chunk prefab.
+class DifficultyBracket {
+  const DifficultyBracket({
+    required this.min,
+    required this.max,
+  })  : assert(min <= max),
+        assert(min >= 0),
+        assert(max <= 1.0);
+
+  final double min;
+  final double max;
+
+  bool contains(double value) => value >= min && value <= max;
+}
+
+/// Immutable prefab definition used by the procedural chunk spawner.
+@immutable
+class ChunkPrefab {
+  const ChunkPrefab({
+    required this.id,
+    required this.themes,
+    required this.length,
+    required this.entry,
+    required this.exit,
+    this.difficulty = const DifficultyBracket(min: 0, max: 1),
+    this.tags = const <String>{},
+    this.elements = const <ChunkElement>[],
+    this.isTransition = false,
+    this.isStarter = false,
+    this.isFallback = false,
+  })  : assert(length > 0, 'Chunk length must be positive');
+
+  /// Unique identifier for debugging and analytics.
+  final String id;
+
+  /// Themes that can use this chunk. Empty set means theme-agnostic.
+  final Set<VisualTheme> themes;
+
+  /// Horizontal length (in game units) covered by this chunk.
+  final double length;
+
+  /// Entry interface descriptor.
+  final ChunkEndpoint entry;
+
+  /// Exit interface descriptor.
+  final ChunkEndpoint exit;
+
+  /// Supported difficulty bracket.
+  final DifficultyBracket difficulty;
+
+  /// Arbitrary metadata tags (e.g. `airborne`, `combo`, ...).
+  final Set<String> tags;
+
+  /// Structured description of contained elements.
+  final List<ChunkElement> elements;
+
+  /// `true` if the chunk is intended to bridge height gaps.
+  final bool isTransition;
+
+  /// `true` if this chunk can be used as the first chunk for a run.
+  final bool isStarter;
+
+  /// `true` if this chunk can be used as a last-resort fallback.
+  final bool isFallback;
+
+  bool supportsTheme(VisualTheme theme) => themes.isEmpty || themes.contains(theme);
+
+  bool supportsDifficulty(double value) => difficulty.contains(value);
+}
+
+/// Runtime instance of a chunk placed inside the world.
+class ChunkInstance {
+  ChunkInstance({
+    required this.prefab,
+    required this.startX,
+  }) : assert(startX.isFinite);
+
+  final ChunkPrefab prefab;
+  final double startX;
+
+  double get endX => startX + prefab.length;
+  ChunkEndpoint get entry => prefab.entry;
+  ChunkEndpoint get exit => prefab.exit;
+
+  double get entryHeight => prefab.entry.height;
+  double get exitHeight => prefab.exit.height;
+}

--- a/lib/game/content/pcg/chunk_spawner.dart
+++ b/lib/game/content/pcg/chunk_spawner.dart
@@ -1,0 +1,186 @@
+import 'dart:math' as math;
+
+import '../models/content_models.dart';
+import 'chunk_models.dart';
+
+/// Generates a stream of pre-authored chunks that seamlessly stitch together
+/// based on connector compatibility, theme, and difficulty requirements.
+class ChunkSpawner {
+  ChunkSpawner({
+    required List<ChunkPrefab> prefabs,
+    VisualTheme initialTheme = VisualTheme.classic,
+    double maxHeightDelta = 48,
+    int queueLength = 4,
+    double despawnBuffer = 160,
+    math.Random? random,
+  })  : assert(prefabs.isNotEmpty, 'At least one prefab is required'),
+        _prefabs = List<ChunkPrefab>.unmodifiable(prefabs),
+        _theme = initialTheme,
+        _maxHeightDelta = maxHeightDelta,
+        _queueLength = queueLength < 1
+            ? 1
+            : (queueLength > 8 ? 8 : queueLength),
+        _despawnBuffer = despawnBuffer,
+        _random = random ?? math.Random();
+
+  final List<ChunkPrefab> _prefabs;
+  final double _maxHeightDelta;
+  final int _queueLength;
+  final double _despawnBuffer;
+  final math.Random _random;
+  final List<ChunkInstance> _activeChunks = <ChunkInstance>[];
+
+  VisualTheme _theme;
+  double _currentDifficulty = 0.0;
+
+  /// Currently active chunk instances ordered from oldest to newest.
+  List<ChunkInstance> get activeChunks => List<ChunkInstance>.unmodifiable(_activeChunks);
+
+  VisualTheme get theme => _theme;
+  double get currentDifficulty => _currentDifficulty;
+
+  /// Updates the dynamic difficulty value used when selecting future chunks.
+  void updateDifficulty(double difficulty) {
+    _currentDifficulty = difficulty.clamp(0.0, 1.0).toDouble();
+  }
+
+  /// Changes the active environment theme. Already spawned chunks remain as-is
+  /// but future selections will filter by the new theme.
+  void setTheme(VisualTheme theme) {
+    _theme = theme;
+  }
+
+  /// Clears existing chunks and fills the queue starting from [startX].
+  void initialize({ChunkPrefab? startingChunk, double startX = 0}) {
+    _activeChunks.clear();
+    final ChunkPrefab starter = startingChunk ?? _selectStarter();
+    _activeChunks.add(ChunkInstance(prefab: starter, startX: startX));
+    _fillQueue();
+  }
+
+  /// Removes consumed chunks and keeps the queue populated.
+  void advance(double playerX) {
+    if (_activeChunks.isEmpty) {
+      return;
+    }
+    var removed = false;
+    while (_activeChunks.isNotEmpty) {
+      final chunk = _activeChunks.first;
+      final shouldRemove = playerX - chunk.endX > _despawnBuffer;
+      if (!shouldRemove) {
+        break;
+      }
+      _activeChunks.removeAt(0);
+      removed = true;
+    }
+    if (removed || _activeChunks.length < _queueLength) {
+      _fillQueue();
+    }
+  }
+
+  /// Returns the upcoming chunk (if any) without modifying the queue.
+  ChunkInstance? peekNext() {
+    if (_activeChunks.length <= 1) {
+      return null;
+    }
+    return _activeChunks[1];
+  }
+
+  ChunkPrefab _selectStarter() {
+    final starters = _prefabs.where((prefab) =>
+        prefab.isStarter &&
+        prefab.supportsTheme(_theme) &&
+        prefab.supportsDifficulty(_currentDifficulty));
+    if (starters.isNotEmpty) {
+      return starters.first;
+    }
+    final fallback = _prefabs.where((prefab) => prefab.isStarter);
+    if (fallback.isNotEmpty) {
+      return fallback.first;
+    }
+    throw StateError('No starter chunk available for theme $_theme');
+  }
+
+  void _fillQueue() {
+    while (_activeChunks.length < _queueLength) {
+      final nextPrefab = _selectNextPrefab();
+      if (nextPrefab == null) {
+        throw StateError(
+          'Unable to find compatible chunk after ${_activeChunks.last.prefab.id}',
+        );
+      }
+      final startX = _activeChunks.last.endX;
+      _activeChunks.add(ChunkInstance(prefab: nextPrefab, startX: startX));
+    }
+  }
+
+  ChunkPrefab? _selectNextPrefab() {
+    if (_activeChunks.isEmpty) {
+      return _selectStarter();
+    }
+    final previous = _activeChunks.last.prefab;
+
+    ChunkPrefab? pick(List<ChunkPrefab> candidates) {
+      if (candidates.isEmpty) {
+        return null;
+      }
+      return candidates[_random.nextInt(candidates.length)];
+    }
+
+    final directMatches = _prefabs.where((prefab) {
+      if (identical(prefab, previous)) {
+        return false;
+      }
+      if (prefab.isStarter) {
+        return false;
+      }
+      if (!prefab.supportsTheme(_theme)) {
+        return false;
+      }
+      if (!prefab.supportsDifficulty(_currentDifficulty)) {
+        return false;
+      }
+      return previous.exit.isCompatibleWith(
+        prefab.entry,
+        maxHeightDelta: _maxHeightDelta,
+      );
+    }).toList();
+
+    final direct = pick(directMatches);
+    if (direct != null) {
+      return direct;
+    }
+
+    final transitionMatches = _prefabs.where((prefab) {
+      if (!prefab.isTransition) {
+        return false;
+      }
+      if (!prefab.supportsTheme(_theme)) {
+        return false;
+      }
+      return previous.exit.isCompatibleWith(
+        prefab.entry,
+        maxHeightDelta: _maxHeightDelta,
+      );
+    }).toList();
+
+    final transition = pick(transitionMatches);
+    if (transition != null) {
+      return transition;
+    }
+
+    final fallbackMatches = _prefabs.where((prefab) {
+      if (!prefab.isFallback) {
+        return false;
+      }
+      return previous.exit.isCompatibleWith(
+        prefab.entry,
+        maxHeightDelta: _maxHeightDelta,
+      );
+    }).toList();
+
+    return pick(fallbackMatches);
+  }
+}
+
+export 'chunk_models.dart';

--- a/test/game/content/chunk_spawner_test.dart
+++ b/test/game/content/chunk_spawner_test.dart
@@ -1,0 +1,145 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:myapp/game/content/models/content_models.dart';
+import 'package:myapp/game/content/pcg/chunk_models.dart';
+import 'package:myapp/game/content/pcg/chunk_spawner.dart';
+
+void main() {
+  ChunkPrefab createPrefab({
+    required String id,
+    String entryProfile = ChunkProfiles.ground,
+    double entryHeight = 0,
+    String exitProfile = ChunkProfiles.ground,
+    double exitHeight = 0,
+    Set<VisualTheme>? themes,
+    double length = 120,
+    double minDifficulty = 0,
+    double maxDifficulty = 1,
+    bool isStarter = false,
+    bool isTransition = false,
+    bool isFallback = false,
+  }) {
+    return ChunkPrefab(
+      id: id,
+      themes: themes ?? const {VisualTheme.classic},
+      length: length,
+      entry: ChunkEndpoint(profile: entryProfile, height: entryHeight),
+      exit: ChunkEndpoint(profile: exitProfile, height: exitHeight),
+      difficulty: DifficultyBracket(min: minDifficulty, max: maxDifficulty),
+      isStarter: isStarter,
+      isTransition: isTransition,
+      isFallback: isFallback,
+    );
+  }
+
+  test('initializes queue with compatible chunks', () {
+    final starter = createPrefab(
+      id: 'start',
+      entryProfile: ChunkProfiles.start,
+      exitProfile: ChunkProfiles.ground,
+      isStarter: true,
+      isFallback: true,
+    );
+    final ground = createPrefab(id: 'ground');
+    final spawner = ChunkSpawner(
+      prefabs: [starter, ground],
+      queueLength: 3,
+      random: math.Random(1),
+    )..updateDifficulty(0.25);
+
+    spawner.initialize(startingChunk: starter);
+
+    expect(spawner.activeChunks.length, 3);
+    expect(spawner.activeChunks.first.prefab.id, 'start');
+    expect(spawner.activeChunks[1].prefab.id, equals('ground'));
+  });
+
+  test('respects connector compatibility and uses transition chunks', () {
+    final starter = createPrefab(
+      id: 'start',
+      entryProfile: ChunkProfiles.start,
+      exitProfile: ChunkProfiles.ground,
+      isStarter: true,
+      isFallback: true,
+    );
+    final transition = createPrefab(
+      id: 'transition',
+      entryProfile: ChunkProfiles.ground,
+      exitProfile: ChunkProfiles.high,
+      isTransition: true,
+    );
+    final elevated = createPrefab(
+      id: 'elevated',
+      entryProfile: ChunkProfiles.high,
+      exitProfile: ChunkProfiles.high,
+    );
+
+    final spawner = ChunkSpawner(
+      prefabs: [starter, transition, elevated],
+      queueLength: 3,
+      random: math.Random(2),
+    )..updateDifficulty(0.6);
+
+    spawner.initialize(startingChunk: starter);
+
+    expect(spawner.activeChunks[1].prefab.id, 'transition');
+    expect(spawner.activeChunks[2].prefab.id, 'elevated');
+  });
+
+  test('advancing removes consumed chunks and keeps queue filled', () {
+    final starter = createPrefab(
+      id: 'start',
+      entryProfile: ChunkProfiles.start,
+      exitProfile: ChunkProfiles.ground,
+      isStarter: true,
+      isFallback: true,
+      length: 100,
+    );
+    final ground = createPrefab(id: 'ground', length: 140);
+
+    final spawner = ChunkSpawner(
+      prefabs: [starter, ground],
+      queueLength: 3,
+      despawnBuffer: 50,
+      random: math.Random(3),
+    )..updateDifficulty(0.1);
+
+    spawner.initialize(startingChunk: starter);
+    spawner.advance(220); // Should remove the starter chunk.
+
+    expect(spawner.activeChunks.length, 3);
+    expect(spawner.activeChunks.first.prefab.id, isNot('start'));
+  });
+
+  test('difficulty filtering selects appropriate prefab', () {
+    final starter = createPrefab(
+      id: 'start',
+      entryProfile: ChunkProfiles.start,
+      exitProfile: ChunkProfiles.ground,
+      isStarter: true,
+      isFallback: true,
+    );
+    final easy = createPrefab(
+      id: 'easy',
+      minDifficulty: 0,
+      maxDifficulty: 0.5,
+    );
+    final hard = createPrefab(
+      id: 'hard',
+      minDifficulty: 0.6,
+      maxDifficulty: 1.0,
+    );
+
+    final spawner = ChunkSpawner(
+      prefabs: [starter, easy, hard],
+      queueLength: 2,
+      random: math.Random(4),
+    )..updateDifficulty(0.8);
+
+    spawner.initialize(startingChunk: starter);
+
+    expect(spawner.activeChunks[1].prefab.id, 'hard');
+  });
+}


### PR DESCRIPTION
## Summary
- add canonical chunk profiles and prefab metadata to describe PCG segments with connector, difficulty, and element data
- implement a chunk spawner that stitches prefabs while respecting theme, difficulty, and transition/fallback rules to avoid impossible gaps
- cover the spawner with tests for queue management, connector compatibility, and difficulty filtering

## Testing
- `dart test` *(fails: Dart SDK is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9b10d6b0832784550f69e4ca8625