### PR TITLE
Add enemy trio behaviors and visuals

### DIFF
--- a/lib/game/game_painter.dart
+++ b/lib/game/game_painter.dart
@@ -71,6 +71,25 @@ class GamePainter extends CustomPainter {
     begin: Alignment.topCenter,
     end: Alignment.bottomCenter,
   );
+  static final LinearGradient _hopperGradient = const LinearGradient(
+    colors: [Color(0xFFFB923C), Color(0xFFF97316)],
+    begin: Alignment.bottomCenter,
+    end: Alignment.topCenter,
+  );
+  static final LinearGradient _spitterGradient = const LinearGradient(
+    colors: [Color(0xFF7C3AED), Color(0xFFA855F7)],
+    begin: Alignment.bottomCenter,
+    end: Alignment.topCenter,
+  );
+  static final LinearGradient _projectileGradient = const LinearGradient(
+    colors: [Color(0xFF38BDF8), Color(0xFF0EA5E9)],
+    begin: Alignment.bottomCenter,
+    end: Alignment.topCenter,
+  );
+  static final Paint _projectileGlowPaint =
+      Paint()
+        ..color = const Color(0xFF38BDF8).withOpacity(0.45)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 12);
   static final Paint _ceilingPaint =
       Paint()..color = const Color(0xFF1E40AF).withOpacity(0.85);
 
@@ -137,6 +156,10 @@ class GamePainter extends CustomPainter {
 
   void _drawObstacles(Canvas canvas) {
     for (final Obstacle obstacle in obstacles) {
+      if (obstacle.behavior == ObstacleBehavior.spitProjectile) {
+        _drawSpitProjectile(canvas, obstacle);
+        continue;
+      }
       final RRect rrect = RRect.fromRectAndRadius(
         obstacle.rect,
         obstacle.behavior == ObstacleBehavior.ceiling
@@ -154,6 +177,18 @@ class GamePainter extends CustomPainter {
               ..color = const Color(0xFF38BDF8).withOpacity(0.22)
               ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 18);
         canvas.drawRRect(rrect.inflate(6), aura);
+      } else if (obstacle.behavior == ObstacleBehavior.floater) {
+        final Paint aura =
+            Paint()
+              ..color = const Color(0xFF818CF8).withOpacity(0.18)
+              ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 20);
+        canvas.drawRRect(rrect.inflate(8), aura);
+      } else if (obstacle.behavior == ObstacleBehavior.spitter) {
+        final Paint glow =
+            Paint()
+              ..color = const Color(0xFFA855F7).withOpacity(0.2)
+              ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 14);
+        canvas.drawRRect(rrect.inflate(5), glow);
       }
     }
   }
@@ -164,14 +199,33 @@ class GamePainter extends CustomPainter {
         return Paint()
           ..shader = _movingObstacleGradient.createShader(obstacle.rect);
       case ObstacleBehavior.hoveringShard:
+      case ObstacleBehavior.floater:
         return Paint()
           ..shader = _hoverObstacleGradient.createShader(obstacle.rect);
       case ObstacleBehavior.ceiling:
         return _ceilingPaint;
+      case ObstacleBehavior.hopper:
+        return Paint()
+          ..shader = _hopperGradient.createShader(obstacle.rect);
+      case ObstacleBehavior.spitter:
+        return Paint()
+          ..shader = _spitterGradient.createShader(obstacle.rect);
+      case ObstacleBehavior.spitProjectile:
+        return Paint()
+          ..shader = _projectileGradient.createShader(obstacle.rect);
       case ObstacleBehavior.groundBlock:
       default:
         return _obstaclePaint;
     }
+  }
+
+  void _drawSpitProjectile(Canvas canvas, Obstacle obstacle) {
+    final RRect body =
+        RRect.fromRectAndRadius(obstacle.rect, const Radius.circular(10));
+    canvas.drawRRect(body.inflate(6), _projectileGlowPaint);
+    final Paint projectilePaint = Paint()
+      ..shader = _projectileGradient.createShader(obstacle.rect);
+    canvas.drawRRect(body, projectilePaint);
   }
 
   void _drawCoins(Canvas canvas) {

--- a/lib/game/models.dart
+++ b/lib/game/models.dart
@@ -1,7 +1,68 @@
 import 'dart:math' as math;
 import 'dart:ui';
 
-enum ObstacleBehavior { groundBlock, movingHazard, hoveringShard, ceiling }
+enum ObstacleBehavior {
+  groundBlock,
+  movingHazard,
+  hoveringShard,
+  ceiling,
+  hopper,
+  floater,
+  spitter,
+  spitProjectile,
+}
+
+class HopperConfig {
+  HopperConfig({
+    required this.restTop,
+    required this.jumpVelocity,
+    required this.gravity,
+    required this.hopInterval,
+    required this.triggerDistance,
+  });
+
+  final double restTop;
+  final double jumpVelocity;
+  final double gravity;
+  final double hopInterval;
+  final double triggerDistance;
+
+  double timeSinceHop = 0;
+  double verticalVelocity = 0;
+  bool hopping = false;
+}
+
+class SpitterConfig {
+  SpitterConfig({
+    required this.fireInterval,
+    required this.triggerDistance,
+    required this.projectileSpeed,
+    required this.projectileLifetime,
+    required this.projectileSize,
+    this.initialDelay = 0,
+  }) : cooldown = initialDelay;
+
+  final double fireInterval;
+  final double triggerDistance;
+  final double projectileSpeed;
+  final double projectileLifetime;
+  final Size projectileSize;
+  final double initialDelay;
+
+  double cooldown;
+}
+
+class ProjectileConfig {
+  ProjectileConfig({
+    required this.velocity,
+    required this.lifetime,
+  });
+
+  final Offset velocity;
+  final double lifetime;
+
+  double elapsed = 0;
+}
 
 class DrawnLine {
   DrawnLine({required this.points, DateTime? createdAt})
@@ -19,6 +80,9 @@ class Obstacle {
     this.amplitude = 0,
     this.frequency = 0,
     this.phase = 0,
+    this.hopperConfig,
+    this.spitterConfig,
+    this.projectileConfig,
   }) : anchor = anchor ?? rect.topLeft,
        _elapsed = 0;
 
@@ -29,35 +93,110 @@ class Obstacle {
   final double frequency;
   final double phase;
   double _elapsed;
+  final HopperConfig? hopperConfig;
+  final SpitterConfig? spitterConfig;
+  final ProjectileConfig? projectileConfig;
+  bool _expired = false;
 
   bool get isCeiling => behavior == ObstacleBehavior.ceiling;
+  bool get isExpired => _expired;
 
   void translate(double dx) {
     rect = rect.shift(Offset(dx, 0));
     anchor = anchor.translate(dx, 0);
   }
 
-  void update(double dt) {
+  void expire() {
+    _expired = true;
+  }
+
+  List<Obstacle> update(double dt, {Offset? playerPosition}) {
+    final List<Obstacle> spawned = [];
     _elapsed += dt;
     switch (behavior) {
       case ObstacleBehavior.movingHazard:
       case ObstacleBehavior.hoveringShard:
-        if (frequency <= 0 || amplitude <= 0) {
-          return;
+      case ObstacleBehavior.floater:
+        if (frequency > 0 && amplitude > 0) {
+          final double oscillation =
+              math.sin((_elapsed * frequency * math.pi * 2) + phase) * amplitude;
+          rect = Rect.fromLTWH(
+            rect.left,
+            anchor.dy + oscillation,
+            rect.width,
+            rect.height,
+          );
         }
-        final double oscillation =
-            math.sin((_elapsed * frequency * math.pi * 2) + phase) * amplitude;
-        rect = Rect.fromLTWH(
-          rect.left,
-          anchor.dy + oscillation,
-          rect.width,
-          rect.height,
-        );
         break;
       case ObstacleBehavior.groundBlock:
       case ObstacleBehavior.ceiling:
         break;
+      case ObstacleBehavior.hopper:
+        final HopperConfig? config = hopperConfig;
+        if (config == null) {
+          break;
+        }
+        config.timeSinceHop += dt;
+        final bool inRange = playerPosition != null &&
+            playerPosition.dx > rect.left - config.triggerDistance;
+        if (!config.hopping && inRange && config.timeSinceHop >= config.hopInterval) {
+          config.hopping = true;
+          config.verticalVelocity = -config.jumpVelocity;
+          config.timeSinceHop = 0;
+        }
+        if (config.hopping) {
+          config.verticalVelocity += config.gravity * dt;
+          final double nextTop = rect.top + config.verticalVelocity * dt;
+          if (nextTop >= config.restTop) {
+            rect = Rect.fromLTWH(rect.left, config.restTop, rect.width, rect.height);
+            config.hopping = false;
+            config.verticalVelocity = 0;
+          } else {
+            rect = Rect.fromLTWH(rect.left, nextTop, rect.width, rect.height);
+          }
+        }
+        break;
+      case ObstacleBehavior.spitter:
+        final SpitterConfig? config = spitterConfig;
+        if (config == null) {
+          break;
+        }
+        config.cooldown -= dt;
+        final bool playerAhead = playerPosition != null &&
+            playerPosition.dx > rect.left - config.triggerDistance;
+        if (config.cooldown <= 0 && playerAhead) {
+          config.cooldown = config.fireInterval;
+          final Rect projectileRect = Rect.fromLTWH(
+            rect.right - config.projectileSize.width / 2,
+            rect.top - config.projectileSize.height,
+            config.projectileSize.width,
+            config.projectileSize.height,
+          );
+          spawned.add(
+            Obstacle(
+              rect: projectileRect,
+              behavior: ObstacleBehavior.spitProjectile,
+              projectileConfig: ProjectileConfig(
+                velocity: Offset(0, -config.projectileSpeed),
+                lifetime: config.projectileLifetime,
+              ),
+            ),
+          );
+        }
+        break;
+      case ObstacleBehavior.spitProjectile:
+        final ProjectileConfig? projectile = projectileConfig;
+        if (projectile == null) {
+          break;
+        }
+        rect = rect.shift(projectile.velocity * dt);
+        projectile.elapsed += dt;
+        if (projectile.elapsed >= projectile.lifetime) {
+          expire();
+        }
+        break;
     }
+    return spawned;
   }
 }
 


### PR DESCRIPTION
## Summary
- add Hopper, Floater, and Spitter enemy archetypes with bespoke behaviors and projectile support
- update obstacle spawning, ink economy interactions, and coin placement logic to leverage the new enemy types
- enhance obstacle rendering with fresh gradients, glows, and projectile visuals for stronger game-juice feedback

## Testing
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9ea939688327803ae3f601ba5495