### PR TITLE
Add story fragment system for narrative unlocks

### DIFF
--- a/lib/app/quick_draw_dash_app.dart
+++ b/lib/app/quick_draw_dash_app.dart
@@ -7,6 +7,7 @@ import 'package:myapp/features/home/presentation/home_screen.dart';
 import '../core/analytics/analytics_service.dart';
 import '../core/env.dart';
 import '../game/audio/sound_controller.dart';
+import '../game/state/meta_state.dart';
 import '../monetization/storefront_service.dart';
 import '../services/ad_service.dart';
 import '../services/player_wallet.dart';
@@ -31,6 +32,9 @@ class QuickDrawDashApp extends StatelessWidget {
       providers: [
         Provider<AppEnvironment>.value(value: environment),
         Provider<AnalyticsService>.value(value: analytics),
+        ChangeNotifierProvider<MetaProvider>(
+          create: (_) => MetaProvider(),
+        ),
         ChangeNotifierProvider<PlayerWallet>(
           create: (_) {
             final wallet = PlayerWallet();

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -13,6 +13,7 @@ import '../services/player_wallet.dart';
 import 'audio/sound_controller.dart';
 import 'models.dart';
 import 'models/game_models.dart' show RunStats;
+import 'state/meta_state.dart';
 
 enum GamePhase { loading, ready, running, gameOver }
 
@@ -25,6 +26,7 @@ class GameController extends ChangeNotifier {
     required this.adService,
     required this.analytics,
     required this.wallet,
+    required this.meta,
   }) {
     _ticker = vsync.createTicker(_handleTick);
   }
@@ -34,6 +36,7 @@ class GameController extends ChangeNotifier {
   final AdService adService;
   final AnalyticsService analytics;
   final PlayerWallet wallet;
+  final MetaProvider meta;
 
   late final Ticker _ticker;
   GamePhase _phase = GamePhase.loading;
@@ -855,6 +858,8 @@ class GameController extends ChangeNotifier {
       drawTimeMs: _drawTimeMs.round(),
       accidentDeath: _lastDeathCause != null,
     );
+    meta.applyRunStats(runStats);
+    meta.unlockStoryFragmentForRun(runStats);
     final int revivesUsed = _reviveAvailable ? 0 : 1;
     unawaited(
       analytics.logGameEnd(

--- a/lib/game/story/story_fragment.dart
+++ b/lib/game/story/story_fragment.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/game_models.dart';
+
+/// Unlock requirements for a story fragment.
+class StoryUnlockCondition {
+  const StoryUnlockCondition({
+    this.minScore,
+    this.minDuration,
+    this.requireLineUsage = false,
+    this.requireAccidentDeath = false,
+  })  : assert(minScore == null || minScore >= 0),
+        assert(minDuration == null || minDuration >= Duration.zero);
+
+  final int? minScore;
+  final Duration? minDuration;
+  final bool requireLineUsage;
+  final bool requireAccidentDeath;
+
+  bool isSatisfiedBy(RunStats stats) {
+    if (minScore != null && stats.score < minScore!) {
+      return false;
+    }
+    if (minDuration != null && stats.duration < minDuration!) {
+      return false;
+    }
+    if (requireLineUsage && !stats.usedLine) {
+      return false;
+    }
+    if (requireAccidentDeath && !stats.accidentDeath) {
+      return false;
+    }
+    return true;
+  }
+}
+
+/// Narrative fragment unlocked through play.
+@immutable
+class StoryFragment {
+  const StoryFragment({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.unlockCondition,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+  final StoryUnlockCondition unlockCondition;
+}
+
+/// Saved state for a fragment.
+class StoryProgressEntry {
+  StoryProgressEntry({
+    required this.fragmentId,
+    this.unlockedAt,
+    this.viewed = false,
+  });
+
+  final String fragmentId;
+  DateTime? unlockedAt;
+  bool viewed;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': fragmentId,
+      'unlockedAt': unlockedAt?.toIso8601String(),
+      'viewed': viewed,
+    };
+  }
+
+  static StoryProgressEntry fromJson(Map<String, dynamic> json) {
+    return StoryProgressEntry(
+      fragmentId: json['id'] as String,
+      unlockedAt: json['unlockedAt'] != null
+          ? DateTime.tryParse(json['unlockedAt'] as String)
+          : null,
+      viewed: json['viewed'] as bool? ?? false,
+    );
+  }
+}
+
+/// Default library of narrative fragments.
+class StoryFragmentLibrary {
+  StoryFragmentLibrary._();
+
+  static final List<StoryFragment> fragments = List.unmodifiable(<StoryFragment>[
+    StoryFragment(
+      id: 'fragment_awaken',
+      title: '断章1：走り出す理由',
+      body:
+          '靴紐を結ぶ指が震えている。都市のスカイラインが、夜明け前の群青色に滲んだ。'
+          ' 「線を描け。進み続けろ」——遠くの無線がそう囁く。',
+      unlockCondition: StoryUnlockCondition(
+        minDuration: const Duration(seconds: 15),
+      ),
+    ),
+    StoryFragment(
+      id: 'fragment_frequency',
+      title: '断章2：ハミングの発信源',
+      body:
+          '倒れたホッパーの奥で、建材の隙間から揺れる光。そこには古い端末があり、'
+          '同じ周波数で延々と送信を続けていた。「誰かが導いている？」',
+      unlockCondition: StoryUnlockCondition(
+        minScore: 450,
+        requireLineUsage: true,
+      ),
+    ),
+    StoryFragment(
+      id: 'fragment_memory',
+      title: '断章3：失われた街路図',
+      body:
+          '霧の向こう、描いた線が空へ溶ける地点で、かつての街路図が投影された。'
+          'あなたが辿った軌跡と重なり、未到達の場所が淡く光る。',
+      unlockCondition: StoryUnlockCondition(
+        minScore: 900,
+        minDuration: const Duration(seconds: 45),
+      ),
+    ),
+  ]);
+
+  static StoryFragment? byId(String id) {
+    for (final fragment in fragments) {
+      if (fragment.id == id) {
+        return fragment;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a story fragment library with unlock conditions for Quick Draw Dash
- persist story progression in the meta provider and trigger unlocks after game sessions
- surface an in-game overlay for newly unlocked fragments and provide meta state in the app shell

## Testing
- flutter analyze *(fails: flutter not installed in container)*
- dart analyze *(fails: dart not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cba42f2e508327a64dfb54be303a87